### PR TITLE
feat(vmBuilder): add methods to set OS and data disk sizes

### DIFF
--- a/src/Builder/VmBuilder.ts
+++ b/src/Builder/VmBuilder.ts
@@ -39,6 +39,8 @@ class VmBuilder
 
   private _vmInstance: VirtualMachine | undefined = undefined;
   private _ignoreChanges: string[] | undefined = undefined;
+  private _osDiskSize: number = 128;
+  private _dataDiskSize?: number = undefined;
 
   constructor(private args: VmBuilderArgs) {
     super(args);
@@ -84,6 +86,14 @@ class VmBuilder
     this._ignoreChanges = props;
     return this;
   }
+  public withOSDiskSize(props: number): IVmBuilder {
+    this._osDiskSize = props;
+    return this;
+  }
+  public withDataDiskSize(props: number): IVmBuilder {
+    this._dataDiskSize = props;
+    return this;
+  }
 
   private buildLogin() {
     if (!this._generateLogin) return;
@@ -111,6 +121,9 @@ class VmBuilder
         Boolean(this._encryptionProps) || this.args.enableEncryption,
       diskEncryptionSetId: this._encryptionProps?.diskEncryptionSetId,
 
+      osDiskSizeGB: this._osDiskSize,
+      dataDiskSizeGB: this._dataDiskSize,
+      
       subnetId: this._subnetProps!,
       vmSize: this._vmSize!,
       osType: Boolean(this._linuxImage) ? 'Linux' : 'Windows',

--- a/src/Builder/types/vmBuilder.ts
+++ b/src/Builder/types/vmBuilder.ts
@@ -168,4 +168,18 @@ export interface IVmBuilder
    * @returns An instance of IVmBuilder.
    */
   withSchedule(props: VmScheduleType): IVmBuilder;
+
+  /**
+   * Sets the size of the OS disk for the VM.
+   * @param props - The size of the OS disk in GB.
+   * @returns An instance of IVmBuilder.
+   */
+  withOSDiskSize(props: number): IVmBuilder;
+
+  /**
+   * Sets the size of the data disk for the VM.
+   * @param props - The size of the data disk in GB.
+   * @returns An instance of IVmBuilder.
+   */
+  withDataDiskSize(props: number): IVmBuilder;
 }


### PR DESCRIPTION
Introduce `withOSDiskSize` and `withDataDiskSize` methods to allow setting the size of the OS and data disks for the VM. This enhances flexibility in configuring VM disk sizes during the build process.