### PR TITLE
fix: correct template literals in PostgreSQL builder

### DIFF
--- a/src/Builder/PostgreSqlBuilder.ts
+++ b/src/Builder/PostgreSqlBuilder.ts
@@ -197,10 +197,10 @@ class PostgreSqlBuilder
       addCustomSecrets({
         vaultInfo, dependsOn,
         items: [{
-          name: `${this._instanceName}-host}`,
+          name: `${this._instanceName}-host`,
           value: this._sqlInstance!.fullyQualifiedDomainName!,
         }, {
-          name: `${this._instanceName}-username}`,
+          name: `${this._instanceName}-username`,
           value: this._loginInfo!.adminLogin,
         },
         {


### PR DESCRIPTION
Fix incorrect template literals by removing extra closing braces in the `name` property of custom secrets. This ensures proper secret naming and prevents potential runtime errors.