### PR TITLE
refactor(Monitor): remove redundant logAnalyticsDestinationType property

### DIFF
--- a/src/Monitor/index.ts
+++ b/src/Monitor/index.ts
@@ -22,7 +22,6 @@ export const createDiagnostic = (
   new monitor.DiagnosticSetting(
     name,
     {
-      logAnalyticsDestinationType: 'Dedicated',
       logs:logs? logs.map((l) => ({
         categoryGroup: l.categoryGroup,
         enabled: true,


### PR DESCRIPTION
The `logAnalyticsDestinationType` property was redundant and not used in the diagnostic settings. Removing it simplifies the code and improves maintainability.