### PR TITLE
chore: add Azure Key Vault dependencies and refactor VnetBuilder

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
+    "@azure/keyvault-certificates": "^4.9.0",
+    "@azure/keyvault-secrets": "^4.9.0",
     "@drunk-pulumi/azure-providers": "^1.0.9",
     "@pulumi/azure-native": "^3.3.0",
     "@pulumi/azuread": "6.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@azure/keyvault-certificates':
+    specifier: ^4.9.0
+    version: 4.9.0
+  '@azure/keyvault-secrets':
+    specifier: ^4.9.0
+    version: 4.9.0
   '@drunk-pulumi/azure-providers':
     specifier: ^1.0.9
     version: 1.0.9(ts-node@10.9.2)(typescript@5.8.3)

--- a/src/Builder/VnetBuilder.ts
+++ b/src/Builder/VnetBuilder.ts
@@ -25,10 +25,9 @@ const outboundIpName = 'outbound';
 class VnetBuilder
   extends types.Builder<types.VnetBuilderResults>
   implements
-    types.IGatewayFireWallBuilder,
-    types.IVnetBuilder,
-    types.IVnetBuilderStart
-{
+  types.IGatewayFireWallBuilder,
+  types.IVnetBuilder,
+  types.IVnetBuilderStart {
   /** The Instances */
   private _ipAddressInstance: PublicIpAddressPrefixResult | undefined =
     undefined;
@@ -161,7 +160,7 @@ class VnetBuilder
     //IP Address Already provided
     if (this._ipType === 'existing') return;
 
-    const ipNames = [];
+    const ipNames = new Array<string>();
     //No gateway and no firewall then Do nothing
     if (!this._natGatewayEnabled && !this._firewallProps) return;
 
@@ -209,16 +208,16 @@ class VnetBuilder
 
     const subnets = this._subnetProps
       ? Object.keys(this._subnetProps!).map(
-          (k) =>
-            ({
-              name: k,
-              //Link all subnets to nate gateway if available without a firewall.
-              enableNatGateway:
-                this._natGatewayEnabled && !Boolean(this._firewallInstance),
-              //However, till able to overwrite from outside.
-              ...this._subnetProps![k],
-            }) as SubnetProps,
-        )
+        (k) =>
+          ({
+            name: k,
+            //Link all subnets to nate gateway if available without a firewall.
+            enableNatGateway:
+              this._natGatewayEnabled && !Boolean(this._firewallInstance),
+            //However, till able to overwrite from outside.
+            ...this._subnetProps![k],
+          }) as SubnetProps,
+      )
       : [];
 
     this._vnetInstance = Vnet({
@@ -243,15 +242,15 @@ class VnetBuilder
         //Firewall
         firewall: this._firewallProps
           ? {
-              ...this._firewallProps.subnet,
-              enableNatGateway: this._natGatewayEnabled,
-            }
+            ...this._firewallProps.subnet,
+            enableNatGateway: this._natGatewayEnabled,
+          }
           : undefined,
         //Bastion
         bastion: this._bastionProps
           ? {
-              ...this._bastionProps.subnet,
-            }
+            ...this._bastionProps.subnet,
+          }
           : undefined,
         //Gateway
         gatewaySubnet: this._vpnGatewayProps
@@ -292,8 +291,8 @@ class VnetBuilder
       //This is required for Force Tunneling mode
       management: manageSubnetId
         ? {
-            subnetId: manageSubnetId,
-          }
+          subnetId: manageSubnetId,
+        }
         : undefined,
 
       logInfo: this.args.logInfo,


### PR DESCRIPTION
Add '@azure/keyvault-certificates' and '@azure/keyvault-secrets' to dependencies for enhanced Azure integration. Refactor VnetBuilder for improved code readability and maintainability, including array initialization and indentation fixes.